### PR TITLE
fix: don't save temp code locks to the map's save file

### DIFF
--- a/src/AutoCode.cs
+++ b/src/AutoCode.cs
@@ -30,6 +30,17 @@ namespace Oxide.Plugins
     void OnServerSave()
     {
       Data.Save();
+      
+      // Remove all temp code locks - we don't want to save them.
+      foreach (CodeLock codeLock in tempCodeLocks.Values)
+      {
+        if (!codeLock.IsDestroyed)
+        {
+          codeLock.Kill();
+        }
+      }
+      tempCodeLocks.Clear();
+      UnsubscribeFromUnneedHooks();
     }
 
     void OnServerShutdown()


### PR DESCRIPTION
This change has the negative side effect that anyone trying to use a temp code lock when the server saves, will have to start again.